### PR TITLE
Further edited; use semantic linebreaks; add type hinting

### DIFF
--- a/docs/tutorials/dvdremux.md
+++ b/docs/tutorials/dvdremux.md
@@ -41,7 +41,7 @@ Once you are in the DVD Menu, you should be able to navigate to all the episodes
 
 ## Checking for PCM
 
-If your DVD has PCM Audio, it needs to be converted to another format during the remuxing process. 
+If your DVD has PCM Audio, it needs to be converted to another format during the remuxing process.
 We can use ffprobe to check for PCM streams, and to check their stream ids. To do this, run the command:
 
 `ffprobe -f dvdvideo -title <title> -i <path_to_dvd>`
@@ -111,7 +111,7 @@ If your disc has PCM Audio, add:
 
 **After** `-c copy` in the final part of the command.
 
-Replace \<stream_id\> with the stream id you got using ffprobe. If you have multiple PCM streams, add another one for each stream. This will convert the PCM audio to FLAC. 
+Replace \<stream_id\> with the stream id you got using ffprobe. If you have multiple PCM streams, add another one for each stream. This will convert the PCM audio to FLAC.
 
 ==-
 
@@ -149,68 +149,113 @@ Figuring out the correct SAR/PAR to use to correct for this issue is not an exac
 We can the size of black/faded out columns on the image's border, as this can indicate the active area.
 
 ![image](https://github.com/guyman624/thewiki/assets/82007920/bee9d99b-c46d-41cf-afb8-546f53da6c89)
-Here we have a frame from a DVD, we can see that the left and right borders have a fade to black
-If you look closely, the left border has a fade of 5 pixels, while the right has a fade of 4 pixels.
-720 - (5 + 4) = 711, so we now have a rough estimate of an active area. Note that the fade on each border can be off by +-1 pixel often, so we still need to verify this later.
-NTSC has a standard which specifies a 710.85x486 active area, with 711x480 also being valid.
-Since DVDs are all cropped to 480 we have no easy way of telling, but a good assumption to make is that if the disc comes from an analog transfer it's more likely to use the 710.85x486 active area.
-To be further sure of our outcome we can use the other methods in combination with this.
+Here we have a frame from a DVD.
+We can see that the left and right borders have a fade to black.
+If you look closely,
+the left border has a fade of 5 pixels,
+while the right has a fade of 4 pixels.
+720 - (5 + 4) = 711,
+so we now have a rough estimation of the active area.
+Note that the fade on each border can often be off by +-1 pixel,
+so we still need to verify this later.
+
+NTSC has a standard which specifies an active area of 710.85x486,
+with 711x480 also being a valid resolution.
+Since DVDs are all cropped to 480,
+we have no easy way of telling for sure if it's 710.85,
+but a good assumption to make
+is that if the disc comes from an analog transfer,
+it's more likely to use the 710.85x486 active area.
+
+To increase our confidence in these results,
+we can combine them with other methods.
 ==-
 
 ==- 2. Circle check
-We can find an object meant to be a circle and checking which standard results in a perfect circle.
+We can find an object meant to be a circle and check which standard results in a perfect circle.
 
-This one is pretty simple, you find a object that you believe is meant to be a perfect circle and compare different known SAR/PAR standards to a perfect circle that you've overlaid in an image editor.
+This one is pretty simple. You find an object that you believe is meant to be a perfect circle and compare different known SAR/PAR standards to a perfect circle that you've overlaid in an image editor.
 ![image](https://github.com/guyman624/thewiki/assets/82007920/a4d51b7e-b38f-4308-9a8c-30a80889d2f9)
 An example of an exact match using a 2560:2133 SAR/PAR (711x480 active area).
 ==-
 
 ==- 3. Text/logo check
-We can check text or studio logos against a ground truth (Many studio logos can be found in square pixel form)
+We can check text or studio logos against a ground truth (many studio logos can be found in square pixel form).
 
-More or less the same thing as the circle check but using a studio logo instead.
+More or less the same thing as the circle method, but we use a studio logo instead.
 ![image](https://github.com/guyman624/thewiki/assets/82007920/f433ef74-1a15-4216-9c0c-d6100ee1df3a)
-This show ended up being a 4320:4739 SAR/PAR (710.85x486 active area), a difference that the faded column check is unlikely to determine.
+This show ended up having a SAR/PAR of 4320:4739 (710.85x486 active area), a difference the faded column check would be unlikely to determine.
 ==-
 
 ==- 4. Ground truth check
-We can compare the DVD to a natively square pixel source (**Upscales do not qualify**)
+We can compare the DVD to a natively square pixel source (**Upscales do not qualify**).
 
-This one is mainly if you have a DVD only episode of a show. You can downscale the Blu-ray to 864x486, crop it to 864x480, then see which SAR/PAR standard applied to the DVD matches blu-ray.
+This method is mainly for episodes
+that were only released on DVD
+when Blu-rays exist for other episodes,
+such as DVD-only OVAs.
+You can downscale the Blu-ray to 864x486,
+crop it to 864x480,
+and then apply different SAR/PAR standards
+until the DVD matches the Blu-ray.
 ==-
 
-In order to apply a SAR/PAR transform to check using these methods refer to this Vapoursynth code:
-```
-new_sar = vstools.Sar.from_ar(16, 9, 711, 480)
+In order to apply a SAR/PAR transform to check using these methods, refer to this Vapoursynth code snippet:
+
+```py
+from vstools import Sar, mod2
+from vskernels import Bicubic
+
+new_sar = Sar.from_ar(16, 9, 711, 480)
 
 if new_sar > 1:
     width, height = clip.width * float(new_sar), clip.height
 elif new_sar < 1:
     width, height = clip.width, clip.height / float(new_sar)
 
-clip_resized = vskernels.Bicubic.scale(clip, vstools.mod2(width), vstools.mod2(height), keep_ar=True, sar=new_sar)
+clip_resized = Bicubic.scale(clip, mod2(width), mod2(height), keep_ar=True, sar=new_sar)
 ```
-In this case we have a 16:9 DVD with a 711x480 active area, replace the relevant variables to fit your usecase.
 
-After you've determined the correct SAR/PAR we can print out the new display dimensions to use with mkvpropedit like so:
-```
+In this example, we have a 16:9 DVD with a 711x480 active area.
+These values should be replaced to fit your use-case.
+
+Once you've determined the correct SAR/PAR,
+we can print out the new display dimensions
+to use with mkvpropedit like so:
+
+```py
 print([round(width), round(height)])
 ```
 
-After obtaining the new display dimensions you can update your mkv file with them with:
-```
+Once we've obtained these new display dimensions,
+we can edit the mkv with the following terminal command:
+
+```shell
 mkvpropedit test.mkv --edit track:v1 --set display-width=864 --set display-height=480
 ```
-Replacing display-width and display-height with the values you obtained.
 
-This command is incomplete however, in order for fully correct playback we need to additionally set the cropping flags so the video is cropped to it's respective active area. This can be done like so:
-```
+Replace `display-width` and `display-height` with the values you obtained.
+
+This command is incomplete, however.
+In order for fully correct playback
+we need to set additional cropping flags
+so the video is cropped to it's respective active area.
+This can be done by adding the following to the above command:
+
+```shell
 --set pixel-crop-left=5 --set pixel-crop-right=4
 ```
-Once again, replace these values with what fits your source, since this example is a 711 active area we crop to 711 pixels.
-If your disc has black borders on the top or bottom you should additionally set the top/bottom pixel crop flags.
-An example of a complete command would be like so:
-```
+
+Again, replace these values with what fits your source.
+This example is for a 711 active area, so we crop to 711 pixels.
+
+If your disc has black borders on the top or bottom,
+you should additionally set the top/bottom pixel crop flags.
+
+Below is an example of a complete command:
+
+```shell
 mkvpropedit test.mkv --edit track:v1 --set display-width=864 --set display-height=480 --set pixel-crop-left=5 --set pixel-crop-right=4 --set pixel-crop-top=4
 ```
+
 After this your SAR/PAR correction is done and the DVD remux is complete.

--- a/docs/tutorials/dvdremux.md
+++ b/docs/tutorials/dvdremux.md
@@ -215,8 +215,9 @@ and we need to fix this for a remux.
 ### Heuristics to identify SAR/PAR
 
 Figuring out the correct SAR/PAR
-to correct for this issue is not an exact science.
-Over the years there have been many different standards formed,
+to correct for this issue
+is not an exact science.
+Over the years many different standards have been formed,
 and figuring out which your DVD uses
 is not an intuitive process.
 The methods below will be most helpful for this process.

--- a/docs/tutorials/dvdremux.md
+++ b/docs/tutorials/dvdremux.md
@@ -5,10 +5,10 @@ description: Remux DVDs using FFmpeg
 
 # DVD Remuxing
 
-This guide can be used to remux DVDs using FFmpeg and MPC-HC
+This guide can be used to remux DVDs using FFmpeg and MPC-HC.
 
 !!!
-Assistance is available [here](https://discord.gg/XTpc6Fa9eB) if needed.
+Assistance is available in [this Discord server](https://discord.gg/XTpc6Fa9eB) if required.
 !!!
 
 ## Required
@@ -20,10 +20,19 @@ Assistance is available [here](https://discord.gg/XTpc6Fa9eB) if needed.
    - [Setup guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/setup/)
 4. [MKVToolNix](https://mkvtoolnix.download/downloads.html)
 
-
 ## Finding Title/Angle/Chapter (MPC-HC)
 
-DVDs can be split into Titles, Angles and Chapters. A title can be seen as a playlist (or group of playlists if the disc has multiple angles). Angles are used for many things from switching between different editions of the video (Broadcast / Home Video, Theatrical / Director's Cut), to switching between English and Japanese Credits/Typesetting. Note that each angle may have it's own set of chapters. The simplest way to find all 3 for the episodes you are trying to remux is to use MPC-HC. (MPV and VLC lack these capabilities)
+DVDs can be split into Titles, Angles, and Chapters.
+A title can be seen as a playlist
+(or group of playlists if the disc has multiple angles).
+Angles are used for many things,
+from switching between different editions of the video (Broadcast / Home Video, Theatrical / Director's Cut),
+to switching between English and Japanese Credits/Typesetting.
+Note that each angle may have it's own set of chapters.
+The simplest way to find all 3
+for the episodes you are trying to remux
+is to use MPC-HC
+(mpv and VLC lack these capabilities).
 
 1. Mount your ISO/insert your DVD.
 2. In MPC, click *File > Open DVD/BD* and select the root directory of the DVD or folder containing VIDEO_TS.
@@ -32,26 +41,36 @@ DVDs can be split into Titles, Angles and Chapters. A title can be seen as a pla
 You can click *Navigate > Title Menu* to skip the trailers/warnings and get to the Menu.
 !!!
 
-Once you are in the DVD Menu, you should be able to navigate to all the episodes. You will need to take note of a few things about the particular disc you are remuxing.
+Once you are in the DVD Menu,
+you should be able to navigate to all the episodes.
+You will need to take note of a few things
+about the particular disc you are remuxing.
 
 - Find out if the disc has multiple angles. You can change the current angle by going to *Play > Video Angle*
 - Find out if the episodes are all in 1 title, or if each episode has its own title. You can view the current title by going to *Navigate > Titles*
 - If each episode does not have its own title, find out where the Chapter marks are for each episode. You can view the current chapter by going to *Navigate > Chapters*
 
-
 ## Checking for PCM
 
-If your DVD has PCM Audio, it needs to be converted to another format during the remuxing process.
-We can use ffprobe to check for PCM streams, and to check their stream ids. To do this, run the command:
+If your DVD has PCM Audio,
+it needs to be converted to another format
+during the remuxing process.
+We can use ffprobe to check for PCM streams,
+and to check their stream ids.
+To do this, run the command:
 
-`ffprobe -f dvdvideo -title <title> -i <path_to_dvd>`
+```shell
+ffprobe -f dvdvideo -title <title> -i <path_to_dvd>
+```
 
 Replace:
+
 - \<title\> with the title number you got from MPC-HC. This will be an integer from 1-99.
 - \<path_to_dvd\> with the path to the disc image, or the VIDEO_TS folder.
 
 ==- Example ffprobe output snippet
-```
+
+```shell
 Input #0, dvdvideo, from 'D:\VIDEO_TS':
   Duration: 00:00:35.50, start: 0.000000, bitrate: N/A
   Stream #0:0[0x1e0]: Video: mpeg2video, yuv420p(tv, top first), 720x480, SAR 8:9 DAR 4:3, 29.97 fps, 29.97 tbr, 90k tbn
@@ -59,47 +78,72 @@ Input #0, dvdvideo, from 'D:\VIDEO_TS':
         cpb: bitrate max/min/avg: 9800000/0/0 buffer size: 0 vbv_delay: N/A
   Stream #0:1[0xa0](jpn): Audio: pcm_dvd, 48000 Hz, stereo, s16, 1536 kb/s
 ```
+
 ==-
 
-In the example case, there is one audio stream and it is PCM. This stream will need to be converted to another lossless format. Since it is `Stream #0:1`, the stream id is 1.
-
+In the example case,
+there is one audio stream and it is PCM.
+This stream will need to be converted
+to another lossless format.
+Since it is `Stream #0:1`,
+the stream id is `1`.
 
 ## Remuxing
-To remux, you need the latest FFmpeg from the link above. Other builds may not have the proper compile flags to include DVD Demuxing support.
 
-We need to build a ffmpeg command for you to use. You can start with a base of:
+To remux,
+you need the latest FFmpeg from the link above.
+Other builds may not have the proper compile flags
+to include DVD Demuxing support.
 
-`ffmpeg -f dvdvideo -preindex True -title <title>`
+We need to build a ffmpeg command for you to use.
+You can start with a base of:
 
-Replace \<title\> with the title you are looking to remux. This will be an integer from 1-99*. If neither of the following apply to your disc, skip to the end.
+```shell
+ffmpeg -f dvdvideo -preindex True -title <title>
+```
 
-*\*Although 0 is a valid title number, ffmpeg treats it the same as title 1.*
+Replace \<title\> with the title you are looking to remux.
+This will be an integer from 1—99*.
+If neither of the following apply to your disc,
+skip to the end.
+
+*\*Although 0 is a valid title number,*
+*ffmpeg treats it the same as title 1.*
 
 ==- DVDs with multiple angles
+
 If you want to rip a non-default angle from the disc, add:
 
-`-angle <angle>`
+```shell
+-angle <angle>
+```
 
-Replace \<angle\> with the angle number you are looking to remux. This will be an integer from 1-9.
+Replace \<angle\> with the angle number
+you are looking to remux.
+This will be an integer from 1—9.
 
 ==-
 
 ==- DVDs with multiple episodes per Title
 
-If you have multiple episodes per title, you need to add:
+If you have multiple episodes per title,
+you need to add:
 
 `-chapter_start <start_chap> -chapter_end <end_chap>`
 
-Replace \<start_chap\> with the first chapter of the episode you are remuxing. Replace \<end_chap\> with the last chapter of the episode, inclusive. Both accept an integer from 1-99
+Replace \<start_chap\> with the first chapter of the episode you are remuxing.
+Replace \<end_chap\> with the last chapter of the episode, inclusive.
+Both accept an integer from 1—99
 
-If you are including the first or last chapter, you can exclude the respective argument.
+If you are including the first or last chapter,
+you can exclude the respective argument.
 
 ==-
 
+### Final Piece
 
-#### Final Piece
-
-After you have added the rest of the required flags, you can end the command with:
+After you have added the rest of the required flags,
+you can end the command with:
 
 `-i <path_to_dvd> -map 0 -c copy <filename>.mkv`
 
@@ -111,11 +155,15 @@ If your disc has PCM Audio, add:
 
 **After** `-c copy` in the final part of the command.
 
-Replace \<stream_id\> with the stream id you got using ffprobe. If you have multiple PCM streams, add another one for each stream. This will convert the PCM audio to FLAC.
+Replace \<stream_id\> with the stream id you got using ffprobe.
+If you have multiple PCM streams,
+add another one for each stream.
+This will convert the PCM audio to FLAC.
 
 ==-
 
 Replace:
+
 - \<path_to_dvd\> with the path to the disc image or the VIDEO_TS folder.
 - \<filename\> with what you would like the resulting file to be named.
 
@@ -123,29 +171,58 @@ Here is an example of a working command:
 
 `ffmpeg -f dvdvideo -preindex True -title 2 -angle 2 -chapter_start 4 -chapter_end 8 -i example.iso -map 0 -c copy -codec:1 flac test.mkv`
 
-
 ## Correcting SAR/PAR
 
 !!!
-This step, while complicated, is absolutely necessary for your DVD remux to playback correctly. A remux that does not follow this process (or follows it incorrectly) is **broken**.
+This step, while complicated,
+is absolutely necessary for your DVD remux to playback correctly.
+A remux that does not follow this process
+(or follows it incorrectly)
+is **broken**.
 !!!
 
 !!!
-This process will require loading the remux into Vapoursynth, see the setup guide for details.
+This process will require loading the remux into Vapoursynth.
+See the setup guide for details.
 !!!
 
-#### Explanation
-DVDs store what's known as anamorphic video. This means that the video encoded on the disc has a different aspect ratio than how it is meant to be displayed.
-NTSC discs store a 720x480 resolution while PAL discs are 720x576, these are neither 4:3 nor 16:9.
-A [SAR (Sample aspect ratio) aka PAR (Pixel aspect ratio)](https://en.wikipedia.org/wiki/Pixel_aspect_ratio) is applied to the image to stretch it to the intended aspect ratio.
-DVDs were meant primarily for CRT displays, which have [overscan](https://en.wikipedia.org/wiki/Overscan). Overscan was accounted for in the discs by having the [active area](https://en.wikipedia.org/wiki/Overscan#Overscan_amounts) be below 720 pixels, so when the CRT stretches the image a second time nothing important is cropped and the extra stretch results in the true aspect ratio.
-Modern displays do not have overscan, nor do they stretch the image, this means that without correction every DVD will be displayed wrong, and we need to fix this for a remux.
+### Explanation
+
+DVD videos are stored as what's known as anamorphic video.
+This means that the video encoded on the disc
+have a different aspect ratio
+from how it is meant to be displayed.
+NTSC discs store a 720x480 resolution
+while PAL discs are 720x576,
+and neither of these are exactly 4:3 or 16:9.
+
+A [SAR (Sample aspect ratio) aka PAR (Pixel aspect ratio)](https://en.wikipedia.org/wiki/Pixel_aspect_ratio)
+is applied to the image to stretch it to the intended aspect ratio.
+DVDs were meant primarily for CRT displays,
+which have [overscan](https://en.wikipedia.org/wiki/Overscan).
+Overscan was accounted for in the discs
+by having the [active area](https://en.wikipedia.org/wiki/Overscan#Overscan_amounts) be below 720 pixels,
+so when the CRT stretches the image a second time
+nothing important is cropped
+and the extra stretch results in the true aspect ratio.
+Modern displays have neither overscan,
+nor do they stretch the image.
+This means that without correction,
+every DVD will be displayed wrong,
+and we need to fix this for a remux.
 
 
-#### Heuristics to identify SAR/PAR
-Figuring out the correct SAR/PAR to use to correct for this issue is not an exact science. Over the years there have been many different standards formed for anamorphic video and figuring out which your DVD uses is not an intuitive process. The methods below will be most helpful for this process.
+### Heuristics to identify SAR/PAR
+
+Figuring out the correct SAR/PAR
+to correct for this issue is not an exact science.
+Over the years there have been many different standards formed,
+and figuring out which your DVD uses
+is not an intuitive process.
+The methods below will be most helpful for this process.
 
 ==- 1. Faded column check
+
 We can the size of black/faded out columns on the image's border, as this can indicate the active area.
 
 ![image](https://github.com/guyman624/thewiki/assets/82007920/bee9d99b-c46d-41cf-afb8-546f53da6c89)
@@ -172,22 +249,37 @@ we can combine them with other methods.
 ==-
 
 ==- 2. Circle check
-We can find an object meant to be a circle and check which standard results in a perfect circle.
 
-This one is pretty simple. You find an object that you believe is meant to be a perfect circle and compare different known SAR/PAR standards to a perfect circle that you've overlaid in an image editor.
+We can find an object meant to be a circle
+and check which standard results in a perfect circle.
+
+This one is pretty simple.
+You find an object that you believe is meant to be a perfect circle
+and compare different known SAR/PAR standards to a perfect circle
+that you've overlaid in an image editor.
+
 ![image](https://github.com/guyman624/thewiki/assets/82007920/a4d51b7e-b38f-4308-9a8c-30a80889d2f9)
-An example of an exact match using a 2560:2133 SAR/PAR (711x480 active area).
+
+An example of an exact match using a SAR/PAR of 2560:2133 (711x480 active area).
 ==-
 
 ==- 3. Text/logo check
-We can check text or studio logos against a ground truth (many studio logos can be found in square pixel form).
 
-More or less the same thing as the circle method, but we use a studio logo instead.
+We can check text or studio logos
+against a ground truth
+(as many studio logos can be found in square pixel form).
+
+More or less the same thing as the circle method,
+but we use a studio logo instead.
+
 ![image](https://github.com/guyman624/thewiki/assets/82007920/f433ef74-1a15-4216-9c0c-d6100ee1df3a)
-This show ended up having a SAR/PAR of 4320:4739 (710.85x486 active area), a difference the faded column check would be unlikely to determine.
+
+This show ended up having a SAR/PAR of 4320:4739 (710.85x486 active area),
+a difference the faded column check would be unlikely to determine.
 ==-
 
 ==- 4. Ground truth check
+
 We can compare the DVD to a natively square pixel source (**Upscales do not qualify**).
 
 This method is mainly for episodes
@@ -200,7 +292,8 @@ and then apply different SAR/PAR standards
 until the DVD matches the Blu-ray.
 ==-
 
-In order to apply a SAR/PAR transform to check using these methods, refer to this Vapoursynth code snippet:
+In order to apply a SAR/PAR transform to check using these methods,
+refer to this Vapoursynth code snippet:
 
 ```py
 from vstools import Sar, mod2
@@ -216,7 +309,8 @@ elif new_sar < 1:
 clip_resized = Bicubic.scale(clip, mod2(width), mod2(height), keep_ar=True, sar=new_sar)
 ```
 
-In this example, we have a 16:9 DVD with a 711x480 active area.
+In this example,
+we have a 16:9 DVD with an active area of 711x480.
 These values should be replaced to fit your use-case.
 
 Once you've determined the correct SAR/PAR,

--- a/docs/tutorials/dvdremux.md
+++ b/docs/tutorials/dvdremux.md
@@ -35,10 +35,10 @@ is to use MPC-HC
 (mpv and VLC lack these capabilities).
 
 1. Mount your ISO/insert your DVD.
-2. In MPC, click *File > Open DVD/BD* and select the root directory of the DVD or folder containing VIDEO_TS.
+2. In MPC, click _File > Open DVD/BD_ and select the root directory of the DVD or folder containing VIDEO_TS.
 
 !!!
-You can click *Navigate > Title Menu* to skip the trailers/warnings and get to the Menu.
+You can click _Navigate > Title Menu_ to skip the trailers/warnings and get to the Menu.
 !!!
 
 Once you are in the DVD Menu,
@@ -46,9 +46,9 @@ you should be able to navigate to all the episodes.
 You will need to take note of a few things
 about the particular disc you are remuxing.
 
-- Find out if the disc has multiple angles. You can change the current angle by going to *Play > Video Angle*
-- Find out if the episodes are all in 1 title, or if each episode has its own title. You can view the current title by going to *Navigate > Titles*
-- If each episode does not have its own title, find out where the Chapter marks are for each episode. You can view the current chapter by going to *Navigate > Chapters*
+- Find out if the disc has multiple angles. You can change the current angle by going to _Play > Video Angle_
+- Find out if the episodes are all in 1 title, or if each episode has its own title. You can view the current title by going to _Navigate > Titles_
+- If each episode does not have its own title, find out where the Chapter marks are for each episode. You can view the current chapter by going to _Navigate > Chapters_
 
 ## Checking for PCM
 
@@ -103,12 +103,12 @@ ffmpeg -f dvdvideo -preindex True -title <title>
 ```
 
 Replace \<title\> with the title you are looking to remux.
-This will be an integer from 1—99*.
+This will be an integer from 1—99\*.
 If neither of the following apply to your disc,
 skip to the end.
 
-*\*Although 0 is a valid title number,*
-*ffmpeg treats it the same as title 1.*
+_\*Although 0 is a valid title number,_
+_ffmpeg treats it the same as title 1._
 
 ==- DVDs with multiple angles
 
@@ -210,7 +210,6 @@ nor do they stretch the image.
 This means that without correction,
 every DVD will be displayed wrong,
 and we need to fix this for a remux.
-
 
 ### Heuristics to identify SAR/PAR
 


### PR DESCRIPTION
[On semantic linebreaks](https://sembr.org/). This essentially means that incremental edits are much easier to spot individually, as only one line gets adjusted.

[Typehinting codeblocks in markdown](https://www.markdownguide.org/extended-syntax/#syntax-highlighting).